### PR TITLE
Add THIRD_PARTIES.md with third-party attributions

### DIFF
--- a/THIRD_PARTIES.md
+++ b/THIRD_PARTIES.md
@@ -1,0 +1,20 @@
+# THIRD-PARTY ATTRIBUTIONS
+
+This repository includes third-party material not covered by the MIT License.
+
+## tasks.pdf
+
+Copyright (c) 2024 Valerii Krygin (@definability)
+
+Permission:
+Valerii Krygin (@definability) grants Maksym Shylo (@maksymshylo) and Ruslan Khomenko (@Ruslan3584) permission to include and redistribute this file, in its original and unmodified form, within this repository for educational use and portfolio display.
+
+All rights remain with the author.
+
+## Middlebury Stereo Images (2001)
+
+Source: [Middlebury Stereo Datasets](https://vision.middlebury.edu/stereo/data/)
+
+D. Scharstein and R. Szeliski, "A taxonomy and evaluation of dense two-frame stereo correspondence algorithms", International Journal of Computer Vision, 47(1–3):7–42, 2002.
+
+All rights remain with the respective owners.


### PR DESCRIPTION
Add attributions for third-party materials, including tasks.pdf and Middlebury Stereo Images.